### PR TITLE
management network change

### DIFF
--- a/network-telemetry-prometheus/Makefile
+++ b/network-telemetry-prometheus/Makefile
@@ -42,7 +42,7 @@ start_ceos:
 		-e ETBA=1 \
 		-e INTFTYPE=eth \
 		ceosimage:4.20.5F /sbin/init
-	docker network connect prometheus-nornir-snmp-replacement_management --ip 10.200.200.$(IP) $(DEVICE)
+	docker network connect networktelemetryprometheus_management --ip 10.200.200.$(IP) $(DEVICE)
 ifeq ($(DEVICE), $(SPINE00))
 	docker network connect prometheus-nornir-snmp-replacement_link0 --ip 10.200.201.$(IP) $(DEVICE)
 	docker network connect prometheus-nornir-snmp-replacement_link1 --ip 10.200.202.$(IP) $(DEVICE)

--- a/network-telemetry-prometheus/README.md
+++ b/network-telemetry-prometheus/README.md
@@ -42,6 +42,11 @@ This "tutorial" is not going to go super deep into the details, instead, it's go
 
 ## Starting the environment
 
+All components will be downloaded automatically except for Arista devices.  If not already added, download the image using the link above, and add the device to your docker image repository with the command:
+    
+    docker import cEOS-lab.tar.xz ceosimage:4.20.5F
+
+
 All the components will run on different containers so you don't have to worry about the environment. Just start everything by executing:
 
 	make start


### PR DESCRIPTION
Great work!
Wondering if others would need to change the name of the management network like I did.  Received error: overlapping IPs.  When I removed, I saw that networktelemetryprometheus_management was created automatically.  So  I changed the name and it worked.  

I also added a step to the README as it took a couple extra minutes to figure out how to deal with the Arista image and add it to docker.

Please feel free to ignore !  Thanks